### PR TITLE
Lumi: Fix button multipress support

### DIFF
--- a/zigbeelumi/integrationpluginzigbeelumi.json
+++ b/zigbeelumi/integrationpluginzigbeelumi.json
@@ -255,7 +255,7 @@
                     "id": "42c1edba-cc5f-4eb9-84f8-1b0d47a6f95e",
                     "setupMethod": "JustAdd",
                     "createMethods": [ "Auto" ],
-                    "interfaces": [ "longpressbutton", "wirelessconnectable" ],
+                    "interfaces": [ "multibutton", "wirelessconnectable" ],
                     "paramTypes": [
                         {
                             "id": "929eb2be-6d8f-46b7-8cc9-896e7e2c494a",
@@ -309,12 +309,16 @@
                         {
                             "id": "2515e40a-8146-4f11-8d79-2be9e20224e5",
                             "name": "pressed",
-                            "displayName": "Pressed"
-                        },
-                        {
-                            "id": "6e9dda9f-e51b-48c4-9839-01aa33085e2c",
-                            "name": "longPressed",
-                            "displayName": "Long pressed"
+                            "displayName": "Pressed",
+                            "paramTypes": [
+                                {
+                                    "id": "53d10876-f761-40da-b2a8-0e96e772ff3d",
+                                    "name": "buttonName",
+                                    "displayName": "Count",
+                                    "type": "QString",
+                                    "allowedValues": ["1", "2", "3", "4"]
+                                }
+                            ]
                         }
                     ]
                 },


### PR DESCRIPTION
It's not a longpressbutton (longPressed event was never emitted in old code)
but instead can do a press count via a out-of-spec attribute 0x8000.
