### PR TITLE
Generic: Fixes in generic power socket handling (for Lidl power strip)

### DIFF
--- a/zigbeegeneric/README.md
+++ b/zigbeegeneric/README.md
@@ -13,9 +13,10 @@ Installing a manufacturer specific integration plugin will have higher priorty t
 > *IMPORTANT NOTE:* This list is non-exhaustive.
 
 The following list contains devices that are known to work with this plugin. If a ZigBee device is not included in the following 
-list, it does not necessarily imply that the device is not supported. It may still work if it follows the ZigBee specification.
+list, it does not necessarily imply that the device is not supported. Devices certified with the ZigBee logo are most likely to work
+regardless.
 
-> Please report any other devices successfully tested with this plugin to nymea in one of the contact channels found in nymea:apps main menu.
+> Got a device that works but is not listed here? Help us extend this list by letting us know in one of the community channels.
 
 ### On/off power sockets
 
@@ -28,6 +29,8 @@ Known to work:
 * Sonoff ZBMINI Smart Switch (ZBMINI1)
 * Feibit Light Switch (ZSW01)
 * Dresden Electronics (FLS-PP3)
+* Silvercrest (Lidl) Motion sensor (TZ1800)
+* Silvercrest (Lidl) power strip (TS011F)
 
 ### Radiator thermostats
 

--- a/zigbeegeneric/integrationpluginzigbeegeneric.cpp
+++ b/zigbeegeneric/integrationpluginzigbeegeneric.cpp
@@ -216,8 +216,7 @@ bool IntegrationPluginZigbeeGeneric::handleNode(ZigbeeNode *node, const QUuid &n
 void IntegrationPluginZigbeeGeneric::handleRemoveNode(ZigbeeNode *node, const QUuid &networkUuid)
 {
     Q_UNUSED(networkUuid)
-    Thing *thing = m_thingNodes.key(node);
-    if (thing) {
+    foreach (Thing *thing, m_thingNodes.keys(node)) {
         qCDebug(dcZigbeeGeneric()) << node << "for" << thing << "has left the network.";
         emit autoThingDisappeared(thing->id());
 


### PR DESCRIPTION
Smaller bugfixes found when adding a Lidl (Silvercrest) poer strip

* Bind OnOff cluster and configure attribute reporting to smart plugs
* Clean up all things when a single node creates has multiple endpoints creating things
