### PR TITLE
Eurotronic: Queue actions

### DIFF
--- a/zigbeeeurotronic/integrationpluginzigbeeeurotronic.h
+++ b/zigbeeeurotronic/integrationpluginzigbeeeurotronic.h
@@ -35,6 +35,8 @@
 
 #include "extern-plugininfo.h"
 
+#include <QQueue>
+
 class IntegrationPluginZigbeeEurotronic: public ZigbeeIntegrationPlugin
 {
     Q_OBJECT
@@ -60,6 +62,13 @@ public:
 
     void setupThing(ThingSetupInfo *info) override;
     void executeAction(ThingActionInfo *info) override;
+
+private:
+    void sendNextAction();
+
+private:
+    QQueue<ThingActionInfo*> m_actionQueue;
+    ThingActionInfo *m_pendingAction = nullptr;
 };
 
 #endif // INTEGRATIONPLUGINZIGBEEEUROTRONIC_H


### PR DESCRIPTION
This device seems to have some struggles when we send multiple actions simultaneously. I.e. setting the window open lock and the target temperature in one go, would often cause it to get confused and not process the actions at all.