### PR TITLE
Eurotronic: Remove OTA feature for the Spirit

### DIFF
--- a/zigbeeeurotronic/integrationpluginzigbeeeurotronic.cpp
+++ b/zigbeeeurotronic/integrationpluginzigbeeeurotronic.cpp
@@ -78,10 +78,10 @@ void IntegrationPluginZigbeeEurotronic::setupThing(ThingSetupInfo *info)
 
     ZigbeeNode *node = nodeForThing(thing);
     ZigbeeNodeEndpoint *endpoint = node->getEndpoint(0x01);
+    thing->setStateValue("currentVersion", endpoint->deviceVersion());
 
     connectToPowerConfigurationInputCluster(thing, endpoint);
     connectToThermostatCluster(thing, endpoint);
-    connectToOtaOutputCluster(thing, endpoint);
 
     ZigbeeClusterThermostat *thermostatCluster = endpoint->inputCluster<ZigbeeClusterThermostat>(ZigbeeClusterLibrary::ClusterIdThermostat);
     if (!thermostatCluster) {

--- a/zigbeeeurotronic/integrationpluginzigbeeeurotronic.json
+++ b/zigbeeeurotronic/integrationpluginzigbeeeurotronic.json
@@ -13,7 +13,7 @@
                     "name": "spirit",
                     "displayName": "SPIRIT ZigBee ",
                     "createMethods": ["auto"],
-                    "interfaces": ["thermostat", "temperaturesensor", "battery",  "wirelessconnectable", "childlock", "update"],
+                    "interfaces": ["thermostat", "temperaturesensor", "battery",  "wirelessconnectable", "childlock"],
                     "paramTypes": [
                         {
                             "id": "5aff538a-f56d-4e36-b406-b24ef8ef198d",
@@ -156,24 +156,6 @@
                             "displayName": "Version",
                             "type": "QString",
                             "defaultValue": ""
-                        },
-                        {
-                            "id": "dc94b759-71ec-4d86-8984-089ed3573cd8",
-                            "name": "availableVersion",
-                            "displayName": "Available firmware version",
-                            "type": "QString",
-                            "defaultValue": ""
-                        },
-                        {
-                            "id": "97278a2d-4242-433f-815f-29d861e437c5",
-                            "name": "updateProgress",
-                            "displayName": "Update progress",
-                            "type": "uint",
-                            "minValue": 0,
-                            "maxValue": 100,
-                            "unit": "Percentage",
-                            "defaultValue": 0,
-                            "cached": false
                         }
                     ],
                     "actionTypes": [


### PR DESCRIPTION
Even though there is 1 update available for this device, realistically there won't be any more updates. The one available update file is quite old, much older than what comes on devices bought within the last 3 years.

That itself wouldn't be a problem, but the device is implemented rather shitty in a sense that if it gets just a single imageNotify command, it will start polling for new images forever every minute and drain its own battery withing 2 weeks.