### PR TITLE
Refresh battery level when a device reconnects

### DIFF
--- a/common/zigbeeintegrationplugin.cpp
+++ b/common/zigbeeintegrationplugin.cpp
@@ -728,10 +728,21 @@ void ZigbeeIntegrationPlugin::connectToPowerConfigurationInputCluster(Thing *thi
         thing->setStateValue("batteryCritical", alarmState > 0);
     });
 
-    powerCluster->readAttributes({
-                                 ZigbeeClusterPowerConfiguration::AttributeBatteryPercentageRemaining,
-                                 ZigbeeClusterPowerConfiguration::AttributeBatteryAlarmState
-                             });
+    if (endpoint->node()->reachable()) {
+        powerCluster->readAttributes({
+                                     ZigbeeClusterPowerConfiguration::AttributeBatteryPercentageRemaining,
+                                     ZigbeeClusterPowerConfiguration::AttributeBatteryAlarmState
+                                 });
+    }
+
+    connect(endpoint->node(), &ZigbeeNode::reachableChanged, powerCluster, [powerCluster](bool reachable){
+        if (reachable) {
+            powerCluster->readAttributes({
+                                         ZigbeeClusterPowerConfiguration::AttributeBatteryPercentageRemaining,
+                                         ZigbeeClusterPowerConfiguration::AttributeBatteryAlarmState
+                                     });
+        }
+    });
 }
 
 void ZigbeeIntegrationPlugin::connectToThermostatCluster(Thing *thing, ZigbeeNodeEndpoint *endpoint)


### PR DESCRIPTION
We may miss attribute reports while a device is disconnected. This is especially visible when the battery is replaced.
Often devices would not report the new battery level when they run out of battery and a new battery is inserted so things would stick on 0% until either nymea is restarted or the battery goes from 100% to 99%.