### PR TITLE
Don't destroy things when removing ZigBee nodes from the network

### DIFF
--- a/common/zigbeeintegrationplugin.h
+++ b/common/zigbeeintegrationplugin.h
@@ -73,7 +73,9 @@ protected:
     Thing *thingForNode(ZigbeeNode *node);
     ZigbeeNode *nodeForThing(Thing *thing);
 
-    virtual void createThing(const ThingClassId &thingClassId, ZigbeeNode *node, const ParamList &additionalParams = ParamList());
+    virtual Thing *createThing(const ThingClassId &thingClassId, ZigbeeNode *node, const ParamList &additionalParams = ParamList());
+    virtual void createConnections(Thing *thing) = 0;
+
 
     void bindCluster(ZigbeeNodeEndpoint *endpoint, ZigbeeClusterLibrary::ClusterId clusterId, int retries = 3);
 
@@ -94,6 +96,7 @@ protected:
     void configureFanControlInputClusterAttributeReporting(ZigbeeNodeEndpoint *endpoint);
     void configureIasZoneInputClusterAttributeReporting(ZigbeeNodeEndpoint *endpoint);
     void configureWindowCoveringInputClusterLiftPercentageAttributeReporting(ZigbeeNodeEndpoint *endpoint);
+    void configureDoorLockInputClusterAttributeReporting(ZigbeeNodeEndpoint *endpoint);
 
     void connectToPowerConfigurationInputCluster(Thing *thing, ZigbeeNodeEndpoint *endpoint, qreal maxVoltage = 0, qreal minVoltage = 0);
     void connectToThermostatCluster(Thing *thing, ZigbeeNodeEndpoint *endpoint);
@@ -145,6 +148,7 @@ private slots:
     virtual void updateFirmwareIndex();
 
 private:
+    void setupNode(ZigbeeNode *node, Thing *thing);
     FirmwareIndexEntry firmwareInfo(quint16 manufacturerId, quint16 imageType, quint32 fileVersion) const;
     QString firmwareFileName(const FirmwareIndexEntry &info) const;
     FetchFirmwareReply *fetchFirmware(const FirmwareIndexEntry &info);

--- a/zigbeedevelco/integrationpluginzigbeedevelco.h
+++ b/zigbeedevelco/integrationpluginzigbeedevelco.h
@@ -100,6 +100,8 @@ public:
     void executeAction(ThingActionInfo *info) override;
 
 private:    
+    void createConnections(Thing *thing) override;
+
     QString parseDevelcoVersionString(ZigbeeNodeEndpoint *endpoint);
 
     void initIoModule(ZigbeeNode *node);

--- a/zigbeeeurotronic/integrationpluginzigbeeeurotronic.h
+++ b/zigbeeeurotronic/integrationpluginzigbeeeurotronic.h
@@ -64,6 +64,8 @@ public:
     void executeAction(ThingActionInfo *info) override;
 
 private:
+    void createConnections(Thing *thing) override;
+
     void sendNextAction();
 
 private:

--- a/zigbeegeneric/integrationpluginzigbeegeneric.h
+++ b/zigbeegeneric/integrationpluginzigbeegeneric.h
@@ -61,8 +61,8 @@ protected:
 private:
     ZigbeeNodeEndpoint *findEndpoint(Thing *thing);
 
-    void initSimplePowerSocket(ZigbeeNode *node, ZigbeeNodeEndpoint *endpoint);
-    void initDoorLock(ZigbeeNode *node, ZigbeeNodeEndpoint *endpoint);
+    void createConnections(Thing *thing) override;
+
 };
 
 #endif // INTEGRATIONPLUGINZIGBEEGENERIC_H

--- a/zigbeegewiss/integrationpluginzigbeegewiss.cpp
+++ b/zigbeegewiss/integrationpluginzigbeegewiss.cpp
@@ -110,8 +110,16 @@ void IntegrationPluginZigbeeGewiss::setupThing(ThingSetupInfo *info)
         return;
     }
 
-    ZigbeeNode *node = nodeForThing(thing);
+    info->finish(Thing::ThingErrorNoError);
+}
 
+void IntegrationPluginZigbeeGewiss::createConnections(Thing *thing)
+{
+    ZigbeeNode *node = nodeForThing(thing);
+    if (!node) {
+        qCWarning(dcZigbeeGewiss()) << "Node for thing" << thing << "not found.";
+        return;
+    }
 
     if (thing->thingClassId() == gwa1501BinaryInputThingClassId) {
 
@@ -127,7 +135,6 @@ void IntegrationPluginZigbeeGewiss::setupThing(ThingSetupInfo *info)
         connectToOnOffOutputCluster(thing, endpoint1, "Toggle 1", "On 1", "Off 1", "input1");
         connectToOnOffOutputCluster(thing, endpoint2, "Toggle 2", "On 2", "Off 2", "input2");
 
-        info->finish(Thing::ThingErrorNoError);
         return;
 
         // Single channel relay
@@ -151,11 +158,7 @@ void IntegrationPluginZigbeeGewiss::setupThing(ThingSetupInfo *info)
                 thing->setStateValue(gwa1521ActuatorRelayStateTypeId, power);
             });
         }
-        return info->finish(Thing::ThingErrorNoError);
     }
-    qCWarning(dcZigbeeGewiss()) << "Thing class not found" << info->thing()->thingClassId();
-    Q_ASSERT_X(false, "ZigbeeGewiss", "Unhandled thing class");
-    return info->finish(Thing::ThingErrorThingClassNotFound);
 }
 
 void IntegrationPluginZigbeeGewiss::executeAction(ThingActionInfo *info)
@@ -168,7 +171,7 @@ void IntegrationPluginZigbeeGewiss::executeAction(ThingActionInfo *info)
 
     Thing *thing = info->thing();
     ZigbeeNode *node = nodeForThing(info->thing());
-    if (!node->reachable()) {
+    if (!node || !node->reachable()) {
         info->finish(Thing::ThingErrorHardwareNotAvailable);
         return;
     }

--- a/zigbeegewiss/integrationpluginzigbeegewiss.h
+++ b/zigbeegewiss/integrationpluginzigbeegewiss.h
@@ -54,6 +54,8 @@ public:
     void executeAction(ThingActionInfo *info) override;
 
 private:
+    void createConnections(Thing *thing) override;
+
     bool initTemperatureCluster(ZigbeeNode *node, Thing *thing);
 
     void connectToOnOffOutputCluster(Thing *thing, ZigbeeNodeEndpoint *endpoint, const QString &toggleButton, const QString &onButton, const QString &offButton, const QString &powerStateName);

--- a/zigbeejung/integrationpluginzigbeejung.h
+++ b/zigbeejung/integrationpluginzigbeejung.h
@@ -55,6 +55,10 @@ public:
 
     void setupThing(ThingSetupInfo *info) override;
     void executeAction(ThingActionInfo *info) override;
+
+private:
+    void createConnections(Thing *thing) override;
+
 };
 
 #endif // INTEGRATIONPLUGINZIGBEEJUNG_H

--- a/zigbeelumi/integrationpluginzigbeelumi.cpp
+++ b/zigbeelumi/integrationpluginzigbeelumi.cpp
@@ -162,12 +162,19 @@ void IntegrationPluginZigbeeLumi::setupThing(ThingSetupInfo *info)
         return;
     }
 
-    ZigbeeNode *node = nodeForThing(thing);
+    info->finish(Thing::ThingErrorNoError);
+}
 
+void IntegrationPluginZigbeeLumi::createConnections(Thing *thing)
+{
+    ZigbeeNode *node = nodeForThing(thing);
+    if (!node) {
+        qCWarning(dcZigbeeLumi()) << "Unable to get ZigBee node for thing" << thing;
+        return;
+    }
     ZigbeeNodeEndpoint *endpoint = node->getEndpoint(0x01);
     if (!endpoint) {
         qCWarning(dcZigbeeLumi()) << "Zigbee endpoint 1 not found on" << thing;
-        info->finish(Thing::ThingErrorSetupFailed);
         return;
     }
 
@@ -717,14 +724,17 @@ void IntegrationPluginZigbeeLumi::setupThing(ThingSetupInfo *info)
             qCWarning(dcZigbeeLumi()) << "Could not find endpoint 2 on" << thing << node;
         }
     }
-
-    info->finish(Thing::ThingErrorNoError);
 }
 
 void IntegrationPluginZigbeeLumi::executeAction(ThingActionInfo *info)
 {
     Thing *thing = info->thing();
     ZigbeeNode *node = nodeForThing(info->thing());
+    if (!node) {
+        qCWarning(dcZigbeeLumi()) << "Node for thing" << thing << "not found.";
+        info->finish(Thing::ThingErrorHardwareNotAvailable, QT_TR_NOOP("ZigBee node not found in network."));
+        return;
+    }
 
     if (thing->thingClassId() == lumiPowerSocketThingClassId) {
         ZigbeeNodeEndpoint *endpoint = node->getEndpoint(0x01);

--- a/zigbeelumi/integrationpluginzigbeelumi.h
+++ b/zigbeelumi/integrationpluginzigbeelumi.h
@@ -57,6 +57,8 @@ public:
     void executeAction(ThingActionInfo *info) override;
 
 private:
+    void createConnections(Thing *thing) override;
+
     QHash<QString, ThingClassId> m_knownLumiDevices;
 
 };

--- a/zigbeeosram/integrationpluginzigbeeosram.cpp
+++ b/zigbeeosram/integrationpluginzigbeeosram.cpp
@@ -95,6 +95,16 @@ void IntegrationPluginZigbeeOsram::setupThing(ThingSetupInfo *info)
         return;
     }
 
+    info->finish(Thing::ThingErrorNoError);
+}
+
+void IntegrationPluginZigbeeOsram::createConnections(Thing *thing)
+{
+    ZigbeeNode *node = nodeForThing(thing);
+    if (!node) {
+        qCWarning(dcZigbeeOsram()) << "Failed to claim node during setup.";
+        return;
+    }
 
     if (thing->thingClassId() == switchMiniThingClassId) {
         ZigbeeNodeEndpoint *ep1 = node->getEndpoint(1),
@@ -200,10 +210,7 @@ void IntegrationPluginZigbeeOsram::setupThing(ThingSetupInfo *info)
             }
 
         });
-
     }
-
-    info->finish(Thing::ThingErrorNoError);
 }
 
 void IntegrationPluginZigbeeOsram::executeAction(ThingActionInfo *info)

--- a/zigbeeosram/integrationpluginzigbeeosram.h
+++ b/zigbeeosram/integrationpluginzigbeeosram.h
@@ -56,6 +56,8 @@ public:
     void executeAction(ThingActionInfo *info) override;
 
 private:
+    void createConnections(Thing *thing) override;
+
     bool deduplicate(Thing *thing, quint8 transactionSequenceNumber);
     QHash<Thing*, quint8> m_transactionSequenceNumbers;
 

--- a/zigbeephilipshue/integrationpluginzigbeephilipshue.cpp
+++ b/zigbeephilipshue/integrationpluginzigbeephilipshue.cpp
@@ -189,7 +189,17 @@ void IntegrationPluginZigbeePhilipsHue::setupThing(ThingSetupInfo *info)
         return;
     }
 
+    info->finish(Thing::ThingErrorNoError);
+}
+
+void IntegrationPluginZigbeePhilipsHue::createConnections(Thing *thing)
+{
+
     ZigbeeNode *node = nodeForThing(thing);
+    if (!node) {
+        qCWarning(dcZigbeePhilipsHue()) << "Node for thing" << thing << "not found.";
+        return;
+    }
 
 
     if (thing->thingClassId() == dimmableLightThingClassId
@@ -474,13 +484,16 @@ void IntegrationPluginZigbeePhilipsHue::setupThing(ThingSetupInfo *info)
             }
         });
     }
-
-    info->finish(Thing::ThingErrorNoError);
 }
 
 void IntegrationPluginZigbeePhilipsHue::executeAction(ThingActionInfo *info)
 {
     ZigbeeNode *node = nodeForThing(info->thing());
+    if (!node) {
+        qCWarning(dcZigbeePhilipsHue()) << "Node for thing" << info->thing() << "not found.";
+        info->finish(Thing::ThingErrorHardwareNotAvailable, QT_TR_NOOP("ZigBee node not found in network."));
+        return;
+    }
 
     ActionType actionType = info->thing()->thingClass().actionTypes().findById(info->action().actionTypeId());
 

--- a/zigbeephilipshue/integrationpluginzigbeephilipshue.h
+++ b/zigbeephilipshue/integrationpluginzigbeephilipshue.h
@@ -52,10 +52,14 @@ public:
     void setupThing(ThingSetupInfo *info) override;
     void executeAction(ThingActionInfo *info) override;
 
+protected:
+    void createConnections(Thing *thing) override;
+
 private slots:
     void pollLight(Thing *thing);
 
 private:
+
     void bindManufacturerSpecificPhilipsCluster(ZigbeeNodeEndpoint *endpoint);
 
     QHash<Thing*, PluginTimer*> m_pollTimers;

--- a/zigbeeschneiderelectric/integrationpluginzigbeeschneiderelectric.cpp
+++ b/zigbeeschneiderelectric/integrationpluginzigbeeschneiderelectric.cpp
@@ -95,7 +95,16 @@ void IntegrationPluginZigbeeSchneiderElectric::setupThing(ThingSetupInfo *info)
         return;
     }
 
+    info->finish(Thing::ThingErrorNoError);
+}
+
+void IntegrationPluginZigbeeSchneiderElectric::createConnections(Thing *thing)
+{
     ZigbeeNode *node = nodeForThing(thing);
+    if (!node) {
+        qCWarning(dcZigbeeSchneiderElectric()) << "Node for thing" << thing << "not found.";
+        return;
+    }
 
 
     if (thing->thingClassId() == flsAirlink4ThingClassId) {
@@ -105,7 +114,6 @@ void IntegrationPluginZigbeeSchneiderElectric::setupThing(ThingSetupInfo *info)
 
         if (!endpoint21 || !endpoint22) {
             qCWarning(dcZigbeeSchneiderElectric()) << "Unable to get endpoints from device.";
-            info->finish(Thing::ThingErrorHardwareFailure);
             return;
         }
 
@@ -115,11 +123,6 @@ void IntegrationPluginZigbeeSchneiderElectric::setupThing(ThingSetupInfo *info)
         connectToOnOffOutputCluster(thing, endpoint22, "Bottom on", "Bottom off");
         connectToLevelControlOutputCluster(thing, endpoint22, "Bottom up", "Bottom down");
 
-        info->finish(Thing::ThingErrorNoError);
         return;
     }
-
-    qCWarning(dcZigbeeSchneiderElectric()) << "Thing class not found" << info->thing()->thingClassId();
-    Q_ASSERT_X(false, "ZigbeeSchneiderElectric", "Unhandled thing class");
-    return info->finish(Thing::ThingErrorThingClassNotFound);
 }

--- a/zigbeeschneiderelectric/integrationpluginzigbeeschneiderelectric.h
+++ b/zigbeeschneiderelectric/integrationpluginzigbeeschneiderelectric.h
@@ -51,6 +51,9 @@ public:
     bool handleNode(ZigbeeNode *node, const QUuid &networkUuid) override;
 
     void setupThing(ThingSetupInfo *info) override;
+
+protected:
+    void createConnections(Thing *thing) override;
 };
 
 #endif // INTEGRATIONPLUGINZIGBEESCHNEIDERELECTRIC_H

--- a/zigbeetradfri/integrationpluginzigbeetradfri.cpp
+++ b/zigbeetradfri/integrationpluginzigbeetradfri.cpp
@@ -208,12 +208,20 @@ void IntegrationPluginZigbeeTradfri::setupThing(ThingSetupInfo *info)
         return;
     }
 
+    info->finish(Thing::ThingErrorNoError);
+}
+
+void IntegrationPluginZigbeeTradfri::createConnections(Thing *thing)
+{
     ZigbeeNode *node = nodeForThing(thing);
+    if (!node) {
+        qCWarning(dcZigbeeTradfri()) << "Node for thing" << thing << "not found.";
+        return;
+    }
 
     ZigbeeNodeEndpoint *endpoint = node->getEndpoint(1);
     if (!endpoint) {
         qCWarning(dcZigbeeTradfri()) << "Could not find endpoint for" << thing;
-        info->finish(Thing::ThingErrorSetupFailed);
         return;
     }
 
@@ -566,12 +574,16 @@ void IntegrationPluginZigbeeTradfri::setupThing(ThingSetupInfo *info)
     if (thing->thingClassId() == signalRepeaterThingClassId) {
         connectToOtaOutputCluster(thing, endpoint);
     }
-    info->finish(Thing::ThingErrorNoError);
 }
 
 void IntegrationPluginZigbeeTradfri::executeAction(ThingActionInfo *info)
 {
     ZigbeeNode *node = nodeForThing(info->thing());
+    if (!node) {
+        qCWarning(dcZigbeeTradfri()) << "Node for thing" << info->thing() << "not found.";
+        info->finish(Thing::ThingErrorHardwareNotAvailable, QT_TR_NOOP("ZigBee node not found in network."));
+        return;
+    }
 
     ZigbeeNodeEndpoint *endpoint = node->getEndpoint(1);
 

--- a/zigbeetradfri/integrationpluginzigbeetradfri.h
+++ b/zigbeetradfri/integrationpluginzigbeetradfri.h
@@ -59,6 +59,7 @@ public:
     void thingRemoved(Thing *thing) override;
 
 protected:
+    void createConnections(Thing *thing) override;
     QList<FirmwareIndexEntry> firmwareIndexFromJson(const QByteArray &data) const override;
 
 private slots:

--- a/zigbeetuya/integrationpluginzigbeetuya.h
+++ b/zigbeetuya/integrationpluginzigbeetuya.h
@@ -57,6 +57,9 @@ public:
     void executeAction(ThingActionInfo *info) override;
     void thingRemoved(Thing *thing) override;
 
+protected:
+    void createConnections(Thing *thing) override;
+
 private slots:
     void pollEnergyMeters();
 


### PR DESCRIPTION
This makes it easier to remove/rejoin zigbee nodes without losing all magic and other setup related to a thing.

Comes with the cost of having to manually remove a thing when removing a thing from the ZigBee network for good. That should be a bearable cost though, as removing a Thing will still remove the associated node in one go.