### PR TITLE
Tradfri: Fix OTA update action for Starkvind purifier

### DIFF
--- a/zigbeetradfri/integrationpluginzigbeetradfri.cpp
+++ b/zigbeetradfri/integrationpluginzigbeetradfri.cpp
@@ -628,6 +628,11 @@ void IntegrationPluginZigbeeTradfri::executeAction(ThingActionInfo *info)
             bool power = info->action().paramValue(airPurifierChildLockActionChildLockParamTypeId).toBool();
             record.data = ZigbeeDataType(power).data();
         }
+        if (actionType.id() == airPurifierPerformUpdateActionTypeId) {
+            enableFirmwareUpdate(info->thing());
+            executeImageNotifyOtaOutputCluster(info, endpoint);
+            return;
+        }
 
         ZigbeeClusterReply *reply = airPurifierCluster->writeAttributes({record}, Zigbee::Ikea);
         connect(reply, &ZigbeeClusterReply::finished, this, [reply, info](){


### PR DESCRIPTION
Handles missing performUpdate action. Due to the special handling of the starkvind device, the generic action handler won't be called.