### PR TITLE
Typecast to get the correct constructor.

### DIFF
--- a/common/zigbeeintegrationplugin.cpp
+++ b/common/zigbeeintegrationplugin.cpp
@@ -393,7 +393,7 @@ void ZigbeeIntegrationPlugin::configureMeteringInputClusterAttributeReporting(Zi
     currentSummationConfig.dataType = Zigbee::Uint48;
     currentSummationConfig.minReportingInterval = 5;
     currentSummationConfig.maxReportingInterval = 120;
-    currentSummationConfig.reportableChange = ZigbeeDataType(1, Zigbee::Uint48).data();
+    currentSummationConfig.reportableChange = ZigbeeDataType(static_cast<quint64>(1), Zigbee::Uint48).data();
 
     ZigbeeClusterReply *reportingReply = meteringCluster->configureReporting({instantaneousDemandConfig, currentSummationConfig});
     connect(reportingReply, &ZigbeeClusterReply::finished, this, [=](){


### PR DESCRIPTION
When adding a Sonoff S60ZBTPF to my ZigBee network nymea dies with this assertion:

`ASSERT failure in ZigbeeDataType: "invalid data type for qint32 constructor", file zigbeedatatype.cpp, line 267`

Looking through the backtrace in gdb:

```
[...]
#6  0x00007ffff7617eeb in ZigbeeDataType::ZigbeeDataType (this=0x7fffffffc1f0, 
    value=1, dataType=Zigbee::Uint48) at zigbeedatatype.cpp:267
#7  0x00007fffe3824f7a in ZigbeeIntegrationPlugin::configureMeteringInputClusterAttributeReporting (this=0x555555bf0790, endpoint=0x5555559946f0)
    at ../common/zigbeeintegrationplugin.cpp:396
[...]
```

We end up at a line reading

`currentSummationConfig.reportableChange = ZigbeeDataType(1, Zigbee::Uint48).data();`

It seems reasonable that my compiler converts the constant number `1` to and `quint32` and this calls the constructor

`ZigbeeDataType::ZigbeeDataType(quint32 value, Zigbee::DataType dataType)`

which wants `dataType` to be either `Zigbee::Uint24` or `Zigbee::Uint32`.

Fixed with a `static_cast<quint32>` in the pull request commit.